### PR TITLE
Moar match blocks

### DIFF
--- a/src/colour.rs
+++ b/src/colour.rs
@@ -3,10 +3,9 @@ pub fn parse_colour(text: &str) -> String {
     // colours ("ll", "d2", "a3", etc). Otherwise, assume it's something css
     // can parse.
 
-    if text.len() == 2 {
-        format!("var(--{})", text)
-    } else {
-        text.to_string()
+    match text.len() {
+        2 => format!("var(--{})", text),
+        _ => text.to_string()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,13 +22,16 @@ fn main() {
         println!("{}", output);
     } else { // 2 arguments -> output to file
         let dest = &args[2];
-        let file = File::create(dest);
-        if file.is_err() {
-            eprintln!("Could not write to file {}", dest);
-            exit(1);
-        }
-        file.unwrap().write_all(output.as_bytes()).unwrap();
+        
+        match File::create(dest) {
+            Ok(mut file) => file
+                .write_all(output.as_bytes())
+                .unwrap(),
+            Err(_) => {
+                eprintln!("Could not write to file {}", dest);
+                exit(1);
+            }
+        };
     }
-    exit(0);
 }
 


### PR DESCRIPTION
Some low hanging fruit I found. Arguably more idiomatic, removes an unwrap() call, and enables matching on the error down the line.