### PR TITLE
Mdwatch.py usability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 /target
+.venv
 
 *.DS_Store
 

--- a/mdwatch.py
+++ b/mdwatch.py
@@ -24,7 +24,7 @@ class Handler(FileSystemEventHandler):
         if time.time() - last_compile_time < 1: return
 
         print('recompiling...', end='')
-        # either call cargo or the pre-compiled binary
+        # either call cargo or the pre-installed binary
         if debug_mode: os.system(f'cargo run {file_path} {dest_path}')
         else: os.system(f'mdscript {file_path} {dest_path}')
         print('done')
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     # cd to the directory of this script to run cargo
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     # if not debug_mode, build it once in advance
-    if not debug_mode: os.system('cargo build --release')
+    if not debug_mode: os.system('cargo install --path .')
 
     # recompile any time anything changes in the directory
     event_handler = Handler()

--- a/mdwatch.py
+++ b/mdwatch.py
@@ -26,7 +26,7 @@ class Handler(FileSystemEventHandler):
         print('recompiling...', end='')
         # either call cargo or the pre-compiled binary
         if debug_mode: os.system(f'cargo run {file_path} {dest_path}')
-        else: os.system(f'target/debug/mdscript {file_path} {dest_path}')
+        else: os.system(f'mdscript {file_path} {dest_path}')
         print('done')
         #  currently_compiling = False
         last_compile_time = time.time()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+watchdog


### PR DESCRIPTION
A few small changes to make `mdwatch` more usable.

The important change is to have `mdwatch` call mdscript without a hard-coded relative dir, i.e.
on $PATH. This allows the use of a `cargo-install`-ed mdscript binary for example. Additionally, `mdwatch` currently calls a debug build of `mdscript` even when `mdwatch` isn't
called using the `-d` (debug) flag. Any binary on $PATH should be a release binary, or at least
in the user's control.

The other change is just to set up use with a virtual env, done by adding a `requirements.txt` and `.gitignore`-ing .venv.

One alternative I've considered is having calling `target/release/mdscript`, and just having
mdwatch find that relative to itself. It's brittle and imo maybe kinda weird.